### PR TITLE
[certlogic-html] Improve package configuration

### DIFF
--- a/certlogic/certlogic-html/CHANGELOG.md
+++ b/certlogic/certlogic-html/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 0.3.1
+
+* Moved contents of `postinstall` NPM scriptlet to `build` scriptlet, to avoid that this package doesn't install on machines without `mkdir -p`.
+* Update (and lock) dependencies.
+* Update TypeScript compiler configuration.
+
+
 ## 0.3.0
 
 * Add rendering of `dccDateOfBirth` operation.

--- a/certlogic/certlogic-html/package-lock.json
+++ b/certlogic/certlogic-html/package-lock.json
@@ -1,31 +1,23 @@
 {
   "name": "certlogic-html",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "certlogic-html",
-      "version": "0.3.0",
-      "hasInstallScript": true,
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "certlogic-js": "^1.2.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "certlogic-js": "1.2.2",
+        "react": "17.0.2",
+        "react-dom": "17.0.2"
       },
       "devDependencies": {
-        "@types/node": "^17.0.23",
-        "@types/react": "^17.0.43",
-        "@types/react-dom": "^17.0.14",
-        "typescript": "^4.6.3"
+        "@types/react": "17.0.48",
+        "@types/react-dom": "17.0.17",
+        "typescript": "4.7.4"
       }
-    },
-    "node_modules/@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
-      "dev": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
@@ -34,9 +26,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.43",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
-      "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
+      "version": "17.0.48",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.48.tgz",
+      "integrity": "sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -45,12 +37,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz",
-      "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz",
+      "integrity": "sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==",
       "dev": true,
       "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^17"
       }
     },
     "node_modules/@types/scheduler": {
@@ -60,9 +52,9 @@
       "dev": true
     },
     "node_modules/certlogic-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/certlogic-js/-/certlogic-js-1.2.0.tgz",
-      "integrity": "sha512-3LonwPoxhctOQIQmH1/4SA8VRJSSqRy1GYzdSXvSqT08JJJh2XZe+WePF3UZ7XfnF+IAVqO5wDU0C2xP6b7W6Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/certlogic-js/-/certlogic-js-1.2.2.tgz",
+      "integrity": "sha512-ziXgzlsDa9qlm/wFd4BSPNuBH9PiMMNPiUKCueTZgqOUNaPp05VSlNLw1bjoBjdnWnBHkyf3H8/o1HISYHwD+A==",
       "bin": {
         "certlogic-desugar": "dist/misc/desugar-cli.js",
         "certlogic-run": "dist/cli.js",
@@ -134,9 +126,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -148,12 +140,6 @@
     }
   },
   "dependencies": {
-    "@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
-      "dev": true
-    },
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
@@ -161,9 +147,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.43",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
-      "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
+      "version": "17.0.48",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.48.tgz",
+      "integrity": "sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -172,12 +158,12 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz",
-      "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz",
+      "integrity": "sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17"
       }
     },
     "@types/scheduler": {
@@ -187,9 +173,9 @@
       "dev": true
     },
     "certlogic-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/certlogic-js/-/certlogic-js-1.2.0.tgz",
-      "integrity": "sha512-3LonwPoxhctOQIQmH1/4SA8VRJSSqRy1GYzdSXvSqT08JJJh2XZe+WePF3UZ7XfnF+IAVqO5wDU0C2xP6b7W6Q=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/certlogic-js/-/certlogic-js-1.2.2.tgz",
+      "integrity": "sha512-ziXgzlsDa9qlm/wFd4BSPNuBH9PiMMNPiUKCueTZgqOUNaPp05VSlNLw1bjoBjdnWnBHkyf3H8/o1HISYHwD+A=="
     },
     "csstype": {
       "version": "3.0.10",
@@ -244,9 +230,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     }
   }

--- a/certlogic/certlogic-html/package.json
+++ b/certlogic/certlogic-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certlogic-html",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "HTML renderer(s) for CertLogic expressions.",
   "keywords": [
     "json",
@@ -20,22 +20,20 @@
   },
   "main": "dist/index.js",
   "scripts": {
-    "postinstall": "mkdir -p dist",
-    "build": "cp src/styling.css dist/ ; tsc",
+    "build": "mkdir -p dist && cp src/styling.css dist/ && tsc",
     "watch-build": "tsc --watch --incremental",
     "clean": "rm -rf dist/ && rm -rf node_modules/"
   },
   "author": "Meinte Boersma <meinte.boersma@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "certlogic-js": "^1.2.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "certlogic-js": "1.2.2",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@types/node": "^17.0.23",
-    "@types/react": "^17.0.43",
-    "@types/react-dom": "^17.0.14",
-    "typescript": "^4.6.3"
+    "@types/react": "17.0.48",
+    "@types/react-dom": "17.0.17",
+    "typescript": "4.7.4"
   }
 }

--- a/certlogic/certlogic-html/tsconfig.json
+++ b/certlogic/certlogic-html/tsconfig.json
@@ -8,7 +8,10 @@
     "outDir": "dist",
     "jsx": "react",
     "lib": [ "dom", "ES2020" ],
-    "module": "commonjs"
+    "module": "commonjs",
+    "paths": {
+      "react": [ "./node_modules/@types/react" ]
+    }
   },
   "include": [
     "src/**/*.ts*"

--- a/certlogic/certlogic-html/yarn.lock
+++ b/certlogic/certlogic-html/yarn.lock
@@ -2,27 +2,22 @@
 # yarn lockfile v1
 
 
-"@types/node@^17.0.23":
-  "integrity" "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
-  "resolved" "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz"
-  "version" "17.0.23"
-
 "@types/prop-types@*":
   "integrity" "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
   "resolved" "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz"
   "version" "15.7.4"
 
-"@types/react-dom@^17.0.14":
-  "integrity" "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ=="
-  "resolved" "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz"
-  "version" "17.0.14"
+"@types/react-dom@17.0.17":
+  "integrity" "sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg=="
+  "resolved" "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz"
+  "version" "17.0.17"
   dependencies:
-    "@types/react" "*"
+    "@types/react" "^17"
 
-"@types/react@*", "@types/react@^17.0.43":
-  "integrity" "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A=="
-  "resolved" "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz"
-  "version" "17.0.43"
+"@types/react@^17", "@types/react@17.0.48":
+  "integrity" "sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A=="
+  "resolved" "https://registry.npmjs.org/@types/react/-/react-17.0.48.tgz"
+  "version" "17.0.48"
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -33,10 +28,10 @@
   "resolved" "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz"
   "version" "0.16.2"
 
-"certlogic-js@^1.2.0":
-  "integrity" "sha512-3LonwPoxhctOQIQmH1/4SA8VRJSSqRy1GYzdSXvSqT08JJJh2XZe+WePF3UZ7XfnF+IAVqO5wDU0C2xP6b7W6Q=="
-  "resolved" "https://registry.npmjs.org/certlogic-js/-/certlogic-js-1.2.0.tgz"
-  "version" "1.2.0"
+"certlogic-js@1.2.2":
+  "integrity" "sha512-ziXgzlsDa9qlm/wFd4BSPNuBH9PiMMNPiUKCueTZgqOUNaPp05VSlNLw1bjoBjdnWnBHkyf3H8/o1HISYHwD+A=="
+  "resolved" "https://registry.npmjs.org/certlogic-js/-/certlogic-js-1.2.2.tgz"
+  "version" "1.2.2"
 
 "csstype@^3.0.2":
   "integrity" "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
@@ -60,7 +55,7 @@
   "resolved" "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   "version" "4.1.1"
 
-"react-dom@^17.0.2":
+"react-dom@17.0.2":
   "integrity" "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA=="
   "resolved" "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz"
   "version" "17.0.2"
@@ -69,7 +64,7 @@
     "object-assign" "^4.1.1"
     "scheduler" "^0.20.2"
 
-"react@^17.0.2", "react@17.0.2":
+"react@17.0.2":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   "version" "17.0.2"
@@ -85,7 +80,7 @@
     "loose-envify" "^1.1.0"
     "object-assign" "^4.1.1"
 
-"typescript@^4.6.3":
-  "integrity" "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
-  "resolved" "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz"
-  "version" "4.6.3"
+"typescript@4.7.4":
+  "integrity" "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+  "resolved" "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz"
+  "version" "4.7.4"


### PR DESCRIPTION
To avoid installation and compilation failure:

* Moved contents of `postinstall` NPM scriptlet to `build` scriptlet, to avoid that this package doesn't install on machines without `mkdir -p`.
* Update (and lock) dependencies.
* Update TypeScript compiler configuration.