### PR TITLE
Clarify behaviour of plusTime on invalid date(-time)s.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,13 @@ The (JSON Schema) technical specification for the EU DCC can be found [here](htt
 More relevant documents and links can be found [here](./documentation/documents-links.md).
 
 
-## Assumptions
-
-Various code in this repo assumes that you've cloned the following two repos right next to where this repo's cloned:
-
-* [ehn-dcc-schema](https://github.com/ehn-dcc-development/ehn-dcc-schema)
-* [ehn-dcc-valuesets](https://github.com/ehn-dcc-development/ehn-dcc-valuesets)
-* ([dgc-testdata](https://github.com/ehn-dcc-development/dgc-testdata))
-
-
 ## Organisation
 
 This repository contains the following:
 
 * [CertLogic](./certlogic/README.md): a specification, reference implementations for various platforms (JavaScript, Kotlin, Dart), a test suite, a validation tool, and a HTML renderer.
-  CertLogic is generic, and not tied to the DCC, to make it easier to understand, test, expand, etc. independently.
+  CertLogic is “mostly generic and independent of the DCC”, to make it easier to understand, test, expand, etc. independently.
+  ”Mostly” means: only a small part of it is specific to the purpose of validating DCCs using business rules with logic expressed in CertLogic.
 * [DCC Business Rules Utilities](./dcc-business-rules-utils/README.md): a JavaScript library that contains useful “things” for working with EU DCC business rules.
 * [Documentation](./documentation/README.md).
 * [JsonLogic](./jsonlogic/): documentation and code relating to JsonLogic.

--- a/certlogic/certlogic-js/src/test/test-internals.ts
+++ b/certlogic/certlogic-js/src/test/test-internals.ts
@@ -230,6 +230,16 @@ describe("plusTime", () => {
         check("2004-02-29", -2, "year", "2002-03-01T00:00:00.000Z")
     })
 
+    /*
+     * Unit test is skipped because it doesn't succeed.
+     * Currently, the behaviour of `plusTime` on invalid dates like "2021-09-99" is _undefined_.
+     * The specification of CertLogic would have to be expanded to define behavior.
+     */
+    it.skip("doesn't work for invalid dates that only look to be ISO 8601-compliant", () => {
+        throws(() => plusTime("2021-09-99", 0, "day"))
+        throws(() => plusTime("2022-13", 0, "day"))
+    })
+
 
     /*
      * Test with partial dates (in both supported formats), and check whether it coincides with `dccDateOfBirth`.

--- a/certlogic/certlogic-js/src/test/test-js-dates.ts
+++ b/certlogic/certlogic-js/src/test/test-js-dates.ts
@@ -54,5 +54,20 @@ describe("JavaScript Date", () => {
         throws(() => date.toISOString(), /Invalid time value/)
     })
 
+    it("detect dates that look like ISO 8601-dates but are not", () => {
+        const dInvalid = new Date("2021-09-99")
+        isTrue(isNaN(dInvalid as unknown as number))
+        /*
+         * Using isNaN to check for an invalid is a typical JavaScript-“trick”,
+         * which is not actually (currently) used in this codebase.
+         *
+         * The double cast Date --> unknown --> number is necessary to appease TypeScript
+         * enough to not raise a compiler error because a Date can't ever be a number.
+         */
+
+        const dValid = new Date("2021-12-31")
+        isFalse(isNaN(dValid as unknown as number))
+    })
+
 })
 

--- a/certlogic/specification/CHANGELOG.md
+++ b/certlogic/specification/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Date | Changes |
 |---|------|---|
+| 1.3.3 | 20230217 | Clarify `plusTime` w.r.t. behaviour on invalid date(-times).
 | 1.3.2 | 20220512 | Define `plusTime` on partial dates using the DCC DOB operation.
 | 1.3.1 | 20220405 | Add a reference on precise behaviour of `plusTime` w.r.t. leap days.
 | 1.3.0 | 20220330 | Add a `dccDateOfBirth` operation to convert date of birth (DOB) values of the form `YYYY[-MM[-DD]]` in the EU DCC to dates. Also clarify documentation of `plusTime` (again).

--- a/certlogic/specification/README.md
+++ b/certlogic/specification/README.md
@@ -3,7 +3,7 @@
 
 ## Version
 
-The semantic version identification of this specification is: **1.3.2**.
+The semantic version identification of this specification is: **1.3.3**.
 
 The version identification of implementations don't have to be in sync.
 Rather, implementations should specify with which version of the specification they're compatible.
@@ -223,6 +223,15 @@ The following date and date-time formats are allowed:
     YYYY-MM-DDThh:mm:ss.S[+-]hhmm
     YYYY-MM-DDThh:mm:ss.S[+-]h:mm
     YYYY-MM-DDThh:mm:ss.S[+-]hh:mm
+
+These constitute a subset of the [ISO 8601 standard](https://en.wikipedia.org/wiki/ISO_8601).
+The `"date"` and `"date-time"` JSON Schema formats are specified through [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
+(The [RFC 3339 protocol](https://www.rfc-editor.org/rfc/rfc3339) “defines a date and time format for use in Internet protocols that is a profile of the ISO 8601 standard for
+representation of dates and times using the Gregorian calendar”.)
+
+The date(-time) string supplied to `plusTime` is *assumed* to represent a valid ISO 8601-compliant date(-time).
+If it isn't, the behaviour of `plusTime` (and of the whole expression) is *undefined*.
+An example of invalid dates are: `"2021-09-99"` and `"2022-13"`.
 
 The following items describe this conversion for the `plustime` operation in more detail:
 


### PR DESCRIPTION
This fixes issue #129.
Also updated top-level README.